### PR TITLE
Add unhandled expression types to instrumentSolidity.js

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -359,6 +359,60 @@ module.exports = function(contract, fileName, instrumentingActive){
 		}
 	}
 
+	parse["StructDeclaration"] = function(expression, instrument){
+	}
+
+	parse["PragmaStatement"] = function(expression, instrument){
+	}
+
+	parse["UpdateExpression"] = function(expression, instrument){
+	}
+
+	parse["MappingExpression"] = function(expression, instrument){
+	}
+
+	parse["VariableDeclarator"] = function(expression, instrument){
+	}
+
+	parse["EmptyStatement"] = function(expression, instrument){
+	}
+
+	parse["DebuggerStatement"] = function(expression, instrument){
+	}
+
+	parse["IsStatement"] = function(expression, instrument){
+	}
+
+	parse["DeclarativeExpressionList"] = function(expression, instrument){
+	}
+
+	parse["ModifierArgument"] = function(expression, instrument){
+	}
+
+	parse["PlaceholderStatement"] = function(expression, instrument){
+	}
+
+	parse["FunctionName"] = function(expression, instrument){
+	}
+
+	parse["DoWhileStatement"] = function(expression, instrument){
+	}
+
+	parse["WhileStatement"] = function(expression, instrument){
+	}
+
+	parse["ForStatement"] = function(expression, instrument){
+	}
+
+	parse["ForInStatement"] = function(expression, instrument){
+	}
+
+	parse["ContinueStatement"] = function(expression, instrument){
+	}
+
+	parse["BreakStatement"] = function(expression, instrument){
+	}
+
 	var instrumented = parse[result.type](result);
 	//We have to iterate through these injection points in descending order to not mess up
 	//the injection process.


### PR DESCRIPTION
At present, expressions with unhandled `types` throw runtime errors in `instrumentSolidity.js` during the parse table construction sequence. For example, any contract with a `pragma` statement will error with
```
TypeError: parse[expression.body[x].type] is not a function
      at Object.parse.Program (instrumentSolidity.js:403:34)
      at module.exports (instrumentSolidity.js:463:39)
      at Context.<anonymous> (test/ifStatements.js:63:36)
``` 

This PR adds stub entries for some missing `expression.types`  (gleaned from the [solParse pegjs](https://github.com/duaraghav8/solparse/blob/master/solidity-parser.pegjs)).

Question: which (of the added types need their parsing logic fleshed out? The loops?