### PR TITLE
Remove newline condition for statement coverage

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -74,11 +74,8 @@ module.exports = function(contract, fileName, instrumentingActive){
 
 	function instrumentStatement(expression){
 		canCover = false;
+		
 		//Can only instrument here if this is a self-contained statement
-		//So if this is the start of the line, we're good
-		if ( contract.slice(contract.slice(0,expression.start).lastIndexOf('\n'), expression.start).trim().length===0 ){
-			canCover=true;
-		}
 		//If it's preceeded by a '{', we're good
 		if ( contract.slice(contract.slice(0,expression.start).lastIndexOf('{')+1, expression.start).trim().length===0 ){
 			canCover=true;


### PR DESCRIPTION
This PR removes a condition that allows statements to be instrumented if they are preceded by a newline because there are common cases where non-self-contained statements span several lines. For example:
```javascript
if (x == 1)
    throw;
```
produces this error
```
Error: Instrumented solidity invalid: :13:40: Error: Expected primary expression.
{BranchCoverage('test.sol',1,0);throw;}else { BranchCoverage('test.sol',1,1);}
```
and is currently instrumented as
```javascript
StatementCoverage('test.sol',1);
if (x==1) 
                     StatementCoverage('test.sol',2);
{BranchCoverage('test.sol',1,0);throw;}else { BranchCoverage('test.sol',1,1);}
```

This also happens when statements that are arguments to a function  are broken up across lines per the solidity style guide:

```javascript
Person a = Person(
    paramA,
    paramB,
    paramC,
    address(0x579fadbb36a7b7284ef4e50bbc83f3f294e9a8ec)
);
```
I *think* the newline condition can be removed without reducing the accuracy of the coverage and the other two tests in `instrumentStatement`are adequate in themselves. (That definitely needs a sanity check though.) 