### PR TITLE
Fix injection issue for else's without brackets

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -158,8 +158,10 @@ module.exports = function(contract, fileName, instrumentingActive){
 			createOrAppendInjectionPoint(expression.alternate.start, {type: "callBranchEvent", branchId: branchId, locationIdx:1, openBracket: true})
 			createOrAppendInjectionPoint(expression.alternate.end, {type:"closeBracketEnd"});
 			//It should get instrumented when we parse it
-		} else if (expression.alternate){
+		} else if (expression.alternate && contract.slice(expression.alternate.start,expression.alternate.end).trim().indexOf('{')===0){
 			createOrAppendInjectionPoint(expression.alternate.start+1, {type: "callBranchEvent", branchId: branchId, locationIdx: 1})
+		} else if (expression.alternate){
+			createOrAppendInjectionPoint(expression.alternate.start, {type: "callBranchEvent", branchId: branchId, locationIdx: 1})
 		} else {
 			createOrAppendInjectionPoint(expression.consequent.end, {type: "callEmptyBranchEvent", branchId: branchId, locationIdx: 1});
 		}


### PR DESCRIPTION
At present, unbracketed `else` consequents get broken because the coverage statement is injected one character too far. Example: 
```javascript
if (x==1)
  throw;
else 
  x = 5;
```
errors with:
```
Error: Instrumented solidity invalid: :14:48: Error: Expected primary expression.
              xBranchCoverage('test.sol',1,1); = 5;
```

This PR adds bracket management logic that currently exists for the `if` statement to the `else` statement.  