### PR TITLE
Check for null argument in returnStatement parsing

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -204,7 +204,9 @@ module.exports = function(contract, fileName, instrumentingActive){
 
 	parse["ReturnStatement"] = function(expression, instrument){
 		if (instrument){instrumentStatement(expression)}
-		parse[expression.argument.type](expression.argument, instrument);
+		if (expression.argument){
+			parse[expression.argument.type](expression.argument, instrument);
+		}
 	}
 
 	parse["NewExpression"] = function(expression, instrument){


### PR DESCRIPTION
Apparently returning without specifying a value is allowed, e.g
```
function Abc( uint x) returns (bool) {
    return;
}
```
This code breaks `instrumentSolidity.js` at returnStatement because `expression.argument` resolves to null and dereferencing it with `expression.argument.type` fails.

This PR adds logic to check that `expression.argument` is non-null. 

