### PR TITLE
Switch from solparse to solidity-parser

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -1,11 +1,11 @@
-// var SolidityParser = require("solidity-parser");
-var solparse = require("solparse");
+var SolidityParser = require("solidity-parser");
+//var solparse = require("solparse");
 
 var path = require("path");
 module.exports = function(contract, fileName, instrumentingActive){
 
-	// var result = SolidityParser.parseFile("./" + pathToFile);
-	var result = solparse.parse(contract);
+	var result = SolidityParser.parse(contract);
+	//var result = solparse.parse(contract);
 	var instrumented = "";
 	const __INDENTATION__ = "    ";
 	var parse = {};
@@ -324,7 +324,10 @@ module.exports = function(contract, fileName, instrumentingActive){
 		}
 
 		for (x in expression.body){
-			parse[expression.body[x].type](expression.body[x], instrument);
+			// Ignore top-level variable declarations grouped together in array by solidity-parser
+			if (!Array.isArray(expression.body[x])){
+				parse[expression.body[x].type](expression.body[x], instrument);
+			}
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ethereumjs-testrpc": "^2.2.7",
     "istanbul": "^0.4.5",
     "shelljs": "^0.7.4",
-    "solparse": "^1.0.15"
+    "solidity-parser": "git+https://github.com/ConsenSys/solidity-parser.git#master"
   },
   "devDependencies": {
     "mocha": "^3.1.0"


### PR DESCRIPTION
It looks like  solparse is getting integrated into solidity-parser (see [here](https://github.com/ConsenSys/solidity-parser/issues/6)) and other parser fixes are being channelled there as well. For example this change to [allow expressions as modifier arguments](https://github.com/ConsenSys/solidity-parser/issues/27) is needed to be able to run against functions like [this](https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/MultisigWallet.sol#L38) in zeppelin-solidity where `sha3` is invoked within a modifier call. 

This PR:
+  replaces solparse with solidity-parser in `package.json` (fetching from the github master)
+  `requires` and runs solidity-parser in `instrumentSolidity.js`.  
+ checks for and ignores contract-level variable declarations. Solidity-parser differs from solparse in that it groups these together in a sub-array like a block statement. Solcover currently expects the contract body to be all objects and throws an error when it hits the array. I don't *think* this change alters current behavior - e.g. top level var declarations aren't being instrumented.  
