### PR TITLE
Handle empty function body edge case

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -135,10 +135,15 @@ module.exports = function(contract, fileName, instrumentingActive){
 		var startcol = expression.start - contract.slice(0,expression.start).lastIndexOf('\n') -1;
 		var endlineDelta = contract.slice(expression.start).indexOf('{')+1;
 		var functionDefinition = contract.slice(expression.start, expression.start + endlineDelta);
+		var lastChar = contract.slice(expression.start, expression.start + endlineDelta + 1).slice(-1);
 		var endline = startline + (functionDefinition.match(/\n/g)||[]).length;
 		var endcol = functionDefinition.length - functionDefinition.lastIndexOf('\n')
 		fnMap[fnId] = {name: expression.name, line: linecount, loc:{start:{line: startline, column:startcol},end:{line:endline, column:endcol}}}
-		createOrAppendInjectionPoint(expression.start + endlineDelta+1,{type: "callFunctionEvent", fnId: fnId} );
+		if (lastChar === '}'){
+		    createOrAppendInjectionPoint(expression.start + endlineDelta,{type: "callFunctionEvent", fnId: fnId} );
+		} else {
+		    createOrAppendInjectionPoint(expression.start + endlineDelta+1,{type: "callFunctionEvent", fnId: fnId} );
+		}
 	}
 
 	function instrumentIfStatement(expression){


### PR DESCRIPTION
There is a very marginal edge case for parsing function declarations where the function body is empty and there are no spaces between the body brackets e.g. 
```
function emptyBody(uint x){} 
```
An example of someone legitimately using this form can be seen in [this gnosis contract](https://github.com/ConsenSys/gnosis-contracts/blob/master/contracts/solidity/Oracles/AbstractOracle.sol#L13).
 
Solcover near-misses getting the instrument event inside the function body here and errors with
```
Error: Instrumented solidity invalid: :8:49: Error: Expected identifier, got 'LParen'
    function emptyBody(uint x){}FunctionCoverage('test.sol',1);
```

This PR adds logic to check for the existence of this case and modifies the injection start point by one position. 
