### PR TITLE
Update testrpc, vm, and re-patch

### DIFF
--- a/hookIntoEvents.patch
+++ b/hookIntoEvents.patch
@@ -1,5 +1,5 @@
---- opFns.js.orig	2016-07-04 17:29:54.000000000 +0100
-+++ opFns.js	2016-09-30 12:30:33.000000000 +0100
+--- opFns.js.orig   2016-12-19 15:10:12.000000000 -0800
++++ opFns.js    2016-12-19 15:15:51.000000000 -0800
 @@ -6,6 +6,7 @@
  const logTable = require('./logTable.js')
  const ERROR = constants.ERROR
@@ -8,23 +8,23 @@
  
  // the opcode functions
  module.exports = {
-@@ -499,7 +500,6 @@
+@@ -489,7 +490,7 @@
      memLength = utils.bufferToInt(memLength)
      const numOfTopics = runState.opCode - 0xa0
      const mem = memLoad(runState, memOffset, memLength)
 -    subGas(runState, new BN(numOfTopics * fees.logTopicGas.v + memLength * fees.logDataGas.v))
++    //subGas(runState, new BN(numOfTopics * fees.logTopicGas.v + memLength * fees.logDataGas.v))
  
      // add address
      var log = [runState.address]
-@@ -507,6 +507,12 @@
+@@ -497,6 +498,11 @@
  
      // add data
      log.push(mem)
-+    //Added to allow tracking of instrumentation even for .call() and throw
 +    var toWrite = {};
-+    toWrite.address= log[0].toString('hex');
++    toWrite.address= log[0].toString('hex')
 +    toWrite.topics = log[1].map(function(x){return x.toString('hex')})
-+    toWrite.data = log[2].toString('hex');
++    toWrite.data = log[2].toString('hex')
 +    fs.appendFileSync('./allFiredEvents', JSON.stringify(toWrite) + '\n')
      runState.logs.push(log)
    },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ethereumjs-testrpc": "^2.2.7",
+    "ethereumjs-testrpc": "^3.0.3",
     "istanbul": "^0.4.5",
     "shelljs": "^0.7.4",
     "solidity-parser": "git+https://github.com/ConsenSys/solidity-parser.git#master"


### PR DESCRIPTION
Cool patch for getting events from a `call` appears to have stopped working with `testrpc 2.2.7`. If you run solcover on the default truffle project you can see the methods he invokes by call aren't getting logged. This might be because there was a long period when either vm or testrpc was having trouble with events? 

This PR upgrades testrpc to latest and updates the patch (there's been some line drift). Call event capture is restored.  Incidentally - this will mean that users have be running node 6.9.1 or greater because those projects have all moved that way. 