### PR TITLE
Add circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+  pre:
+    - npm install -g truffle


### PR DESCRIPTION
`circe.yml` wasn't hidden, it's just that all the defaults worked for us! We don't need a full file, just to tweak the stages that are useful for us. So this file runs with all the defaults, but also installs `truffle` during the dependencies stage.

Closes #21, closes #22