### PR TITLE
solidity-parser upgrades

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -331,10 +331,7 @@ module.exports = function(contract, fileName, instrumentingActive){
 		}
 
 		for (x in expression.body){
-			// Ignore top-level variable declarations grouped together in array by solidity-parser
-			if (!Array.isArray(expression.body[x])){
-				parse[expression.body[x].type](expression.body[x], instrument);
-			}
+			parse[expression.body[x].type](expression.body[x], instrument);
 		}
 	}
 
@@ -425,6 +422,9 @@ module.exports = function(contract, fileName, instrumentingActive){
 	}
 
 	parse["BreakStatement"] = function(expression, instrument){
+	}
+
+	parse["StateVariableDeclaration"] = function(expression, instrument){
 	}
 
 	var instrumented = parse[result.type](result);

--- a/test/statements.js
+++ b/test/statements.js
@@ -44,7 +44,7 @@ describe('generic statements', function(){
     var output = solc.compile(info.contract, 1); 
     util.report(output.errors);
   })
-  it.only('should cover a statement following a close brace', (done) => {
+  it('should cover a statement following a close brace', (done) => {
     const contract = util.getCode('statements/post-close-brace.sol');
     const info = getInstrumentedVersion(contract, "test.sol", true);
     const coverage = new CoverageMap();


### PR DESCRIPTION
**WARNING: NOT MERGEABLE** 

This PR is a place to add changes necessary to upgrade to the next version of solidity-parser. SP is pre-alpha and being revised to fix bugs, follow the official grammar more closely and be more descriptive / less permissive. Occasionally node types will get added, AST structure will change, etc. As commits are made here, I'll edit the changelog that follows.

+ Added `StateVariableDeclaration` stub to parse table.
+ Reverted changes made in #10 that expected contract level variable declarations to be in an array.

If tests pass CI, it's because the solidity-parser is pinned to `#master`. It shouldn't be.  
