### PR TITLE
Add unit tests for conditional, binary and new statements

### DIFF
--- a/instrumentSolidity.js
+++ b/instrumentSolidity.js
@@ -28,12 +28,13 @@ module.exports = function instruentSolidity(contract, fileName, instrumentingAct
     // The only time we instrument an assignment expression is if there's a conditional expression on
     // the right
     if (expression.right.type === 'ConditionalExpression') {
-      if (expression.left.type === 'DeclarativeExpression') {
+      if (expression.left.type === 'DeclarativeExpression' || expression.left.type==="Identifier") {
         // Then we need to go from bytes32 varname = (conditional expression)
         // to             bytes32 varname; (,varname) = (conditional expression)
         createOrAppendInjectionPoint(expression.left.end, {
           type: 'literal', string: '; (,' + expression.left.name + ')',
         });
+        instrumentConditionalExpression(expression.right);
       } else {
         console.log(expression.left);
         process.exit();
@@ -238,11 +239,12 @@ module.exports = function instruentSolidity(contract, fileName, instrumentingAct
   };
 
   parse.ConditionalExpression = function parseConditionalExpression(expression, instrument) {
+  	if (instrument){ instrumentStatement(expression) }
     if (instrument) { instrumentConditionalExpression(expression); }
-    parse[expression.test.left.type](expression.test.left, instrument);
-    parse[expression.test.right.type](expression.test.right, instrument);
-    parse[expression.consequent.type](expression.consequent, instrument);
-    parse[expression.alternate.type](expression.alternate, instrument);
+    //parse[expression.test.left.type](expression.test.left, instrument);
+    //parse[expression.test.right.type](expression.test.right, instrument);
+    //parse[expression.consequent.type](expression.consequent, instrument);
+    //parse[expression.alternate.type](expression.alternate, instrument);
   };
 
   parse.Identifier = function parseIdentifier(expression, instrument) {

--- a/test/conditional.js
+++ b/test/conditional.js
@@ -1,0 +1,130 @@
+const solc = require('solc');
+const path = require('path');
+const getInstrumentedVersion = require('./../instrumentSolidity.js');
+const util = require('./util/util.js');
+const CoverageMap = require('./../coverageMap');
+const vm = require('./util/vm');
+const assert = require('assert');
+
+describe('conditional statements', function(){
+
+  const filePath = path.resolve('./test.sol');
+  const pathPrefix = './';
+
+  it('should cover a conditional that reaches the consequent (same-line)', (done) => {
+    const contract = util.getCode('conditional/sameline-consequent.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+    
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [1, 0]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  it('should cover a conditional that reaches the alternate (same-line)', (done) => {
+    const contract = util.getCode('conditional/sameline-alternate.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [0, 1]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  it('should cover a conditional that reaches the consequent (multi-line)', (done) => {
+    const contract = util.getCode('conditional/multiline-consequent.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [1, 0]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  it('should cover a conditional that reaches the alternate (multi-line)', (done) => {
+    const contract = util.getCode('conditional/multiline-alternate.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [0, 1]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  it('should cover a DeclarativeExpression assignment by conditional that reaches the alternate', (done) => {
+    const contract = util.getCode('conditional/declarative-exp-assignment-alternate.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    // Runs bool z = (x) ? false : true;
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [0, 1]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  it('should cover an Identifier assignment by conditional that reaches the alternate', (done) => {
+    const contract = util.getCode('conditional/identifier-assignment-alternate.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    // Runs z = (x) ? false : true;
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1, 8: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [0, 1]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1, 4: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });
+
+  // Solcover has trouble with this case. The conditional coverage strategy relies on being able to 
+  // reference the left-hand variable before its value is assigned. Solidity doesn't allow this for 'var'. 
+  
+  /*it('should cover a variable delcaration assignment by conditional that reaches the alternate', (done) => {
+    const contract = util.getCode('conditional/variable-decl-assignment-alternate.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+    // Runs var z = (x) ? y = false : y = false;
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {5: 1, 6: 1, 7: 1});
+      assert.deepEqual(mapping[filePath].b, {'1': [0, 1]});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1});
+      done();
+    }).catch(done);
+  });*/
+})

--- a/test/expressions.js
+++ b/test/expressions.js
@@ -1,0 +1,32 @@
+var solc = require('solc');
+var getInstrumentedVersion = require('./../instrumentSolidity.js');
+var util = require('./util/util.js');
+const CoverageMap = require('./../coverageMap');
+const path = require('path');
+const vm = require('./util/vm');
+const assert = require('assert');
+
+/**
+ * NB: passing '1' to solc as an option activates the optimiser
+ * NB: solc will throw if there is a compilation error, causing the test to fail
+ *     and passing the error to mocha.
+ */
+describe('generic expressions', function(){
+  const filePath = path.resolve('./test.sol');
+  const pathPrefix = './';
+
+  it('should compile after instrumenting a single binary expression', function(){
+    var contract = util.getCode('expressions/single-binary-expression.sol');
+    var info = getInstrumentedVersion(contract, filePath, true);
+    var output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  })
+
+  it('should compile after instrumenting a new expression', function(){
+    var contract = util.getCode('expressions/new-expression.sol');
+    var info = getInstrumentedVersion(contract, filePath, true);
+    var output = solc.compile(info.contract, 1);
+    util.report(output.errors);
+  })
+
+})

--- a/test/sources/conditional/declarative-exp-assignment-alternate.sol
+++ b/test/sources/conditional/declarative-exp-assignment-alternate.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = false;
+        var y = false;
+        bool z = (x) ? false : true;
+    }
+}

--- a/test/sources/conditional/identifier-assignment-alternate.sol
+++ b/test/sources/conditional/identifier-assignment-alternate.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = false;
+        var y = false;
+        var z = false;
+        z = (x) ? false : true;
+    }
+}

--- a/test/sources/conditional/multiline-alternate.sol
+++ b/test/sources/conditional/multiline-alternate.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = false;
+        var y = false;
+        (x) 
+            ? y = false  
+            : y = false;
+    }
+}

--- a/test/sources/conditional/multiline-consequent.sol
+++ b/test/sources/conditional/multiline-consequent.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = true;
+        var y = false;
+        (x) 
+            ? y = false  
+            : y = false;
+    }
+}

--- a/test/sources/conditional/sameline-alternate.sol
+++ b/test/sources/conditional/sameline-alternate.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = false;
+        var y = false;
+        (x) ? y = false : y = false;
+    }
+}

--- a/test/sources/conditional/sameline-consequent.sol
+++ b/test/sources/conditional/sameline-consequent.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = true;
+        var y = false;
+        (x) ? y = false : y = false;
+    }
+}

--- a/test/sources/conditional/variable-decl-assignment-alternate.sol
+++ b/test/sources/conditional/variable-decl-assignment-alternate.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a() {
+        var x = false;
+        var y = false;
+        var z = (x) ? false : true;
+    }
+}

--- a/test/sources/expressions/new-expression.sol
+++ b/test/sources/expressions/new-expression.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a(uint x) {
+      new Test2(x);
+    }
+}
+contract Test2 {
+    function Test2(uint x) {
+      x+1;
+    }
+}

--- a/test/sources/expressions/single-binary-expression.sol
+++ b/test/sources/expressions/single-binary-expression.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.3;
+
+contract Test {
+    function a(uint x) {
+      x+1;
+    }
+}


### PR DESCRIPTION
Some logic for parsing conditional expressions has been changed to address compilation issues. 
+ Lines that parse the test have been commented out: the AST structure no longer matches. 
+ Lines that parse the consequent and alternate were commented out: statement coverage wasn't getting inside the injected parens, which caused problems.
+ Added `Identifier` as a type of node that can be assigned to conditionally

It looks like istanbul treats [conditional expressions as single statements](https://github.com/gotwarlost/istanbul/blob/master/test/instrumentation/test-statement.js#L19), so I think solcover's test results now match theirs. Was the following the path of least resistance here, not necessarily the correct path. 

