### PR TITLE
Add unit test for LibraryStatement, UsingStatement, lib method calls

### DIFF
--- a/test/sources/statements/library.sol
+++ b/test/sources/statements/library.sol
@@ -1,0 +1,21 @@
+/*
+Library and Using statements: invoking 'Test.not' should generate line and statement
+coverage for L 9, 10, and 19, plus function coverage for 'flip' and 'not'. 
+ */
+library Boolean {
+    struct Value { bool val; }
+
+    function flip(Value storage self) internal returns (bool) {
+        self.val = !self.val;
+        return self.val;
+    }
+}
+
+contract Test {
+    using Boolean for Boolean.Value;
+    Boolean.Value b;
+  
+    function not() returns (bool) {
+        return b.flip();
+    }
+}

--- a/test/statements.js
+++ b/test/statements.js
@@ -58,4 +58,20 @@ describe('generic statements', function(){
       done();
     }).catch(done);
   });
+
+  it('should cover a library statement and an invoked library method', (done) => {
+    const contract = util.getCode('statements/library.sol');
+    const info = getInstrumentedVersion(contract, filePath, true);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    vm.execute(info.contract, 'not', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {9: 1, 10: 1, 19: 1});
+      assert.deepEqual(mapping[filePath].b, {});
+      assert.deepEqual(mapping[filePath].s, {1: 1, 2: 1, 3: 1});
+      assert.deepEqual(mapping[filePath].f, {1: 1, 2: 1});
+      done();
+    }).catch(done);
+  });
 })

--- a/test/util/vm.js
+++ b/test/util/vm.js
@@ -46,7 +46,7 @@ function getTypesFromAbi(abi, functionName) {
  * @return {Object}             abi
  */
 function getAbi(source, compilation){
-  const contractNameMatch = source.match(/(?:contract|library)\s([^\s]*)\s*{/)
+  const contractNameMatch = source.match(/(?:contract)\s([^\s]*)\s*{/)
   if(!contractNameMatch) {
     throw new Error('Could not parse contract name from source.')
   }


### PR DESCRIPTION
This PR:
+ adds a unit test that hits the LibraryStatement and UsingStatement code in `instrumentSolidity.js`.  
+ verifies that coverage works for library methods - e.g. instrumentation is generated for both the contract that calls the library and the library itself.
+ modifies a regex in `test/util/vm.js` that allowed the library abi through, causing problems. 
 