### PR TITLE
Revert to solc 0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "istanbul": "^0.4.5",
     "merkle-patricia-tree": "~2.1.2",
     "mocha": "^3.1.0",
-    "solc": "0.4.8"
+    "solc": "0.4.6"
   }
 }

--- a/test/zeppelin.js
+++ b/test/zeppelin.js
@@ -6,14 +6,19 @@ const util = require('./util/util.js');
 
 describe('Battery test of production contracts: OpenZeppelin', () => {
   it('should compile after instrumenting zeppelin-solidity/Bounty.sol', () => {
-    const contract = util.getCode('zeppelin/Bounty.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const bounty = getInstrumentedVersion(util.getCode('zeppelin/Bounty.sol'), 'bounty.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'ownable.sol');
+    const pullPayment = getInstrumentedVersion(util.getCode('zeppelin/pullPayment.sol'), 'pullPayment.sol');
+    const killable = getInstrumentedVersion(util.getCode('zeppelin/Killable.sol'), 'killable.sol');
     const inputs = {
-      'PullPayment.sol': util.getCode('zeppelin/PullPayment.sol'),
-      'Killable.sol': util.getCode('zeppelin/Killable.sol'),
-      'Bounty.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'PullPayment.sol': pullPayment.contract,
+      'Killable.sol': killable.contract,
+      'Bounty.sol': bounty.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 

--- a/test/zeppelin.js
+++ b/test/zeppelin.js
@@ -8,7 +8,7 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   it('should compile after instrumenting zeppelin-solidity/Bounty.sol', () => {
     const bounty = getInstrumentedVersion(util.getCode('zeppelin/Bounty.sol'), 'bounty.sol');
     const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'ownable.sol');
-    const pullPayment = getInstrumentedVersion(util.getCode('zeppelin/pullPayment.sol'), 'pullPayment.sol');
+    const pullPayment = getInstrumentedVersion(util.getCode('zeppelin/PullPayment.sol'), 'pullPayment.sol');
     const killable = getInstrumentedVersion(util.getCode('zeppelin/Killable.sol'), 'killable.sol');
     const inputs = {
       'Ownable.sol': ownable.contract,


### PR DESCRIPTION
Proper writeup coming once master works again, but TLDR somewhere between solc 0.4.6 and 0.4.8 multiply-defined events became unacceptable, and our tests weren't checking for that.