### PR TITLE
Fix Zeppelin tests

### DIFF
--- a/test/zeppelin.js
+++ b/test/zeppelin.js
@@ -6,10 +6,10 @@ const util = require('./util/util.js');
 
 describe('Battery test of production contracts: OpenZeppelin', () => {
   it('should compile after instrumenting zeppelin-solidity/Bounty.sol', () => {
-    const bounty = getInstrumentedVersion(util.getCode('zeppelin/Bounty.sol'), 'bounty.sol');
-    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'ownable.sol');
-    const pullPayment = getInstrumentedVersion(util.getCode('zeppelin/PullPayment.sol'), 'pullPayment.sol');
-    const killable = getInstrumentedVersion(util.getCode('zeppelin/Killable.sol'), 'killable.sol');
+    const bounty = getInstrumentedVersion(util.getCode('zeppelin/Bounty.sol'), 'Bounty.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
+    const pullPayment = getInstrumentedVersion(util.getCode('zeppelin/PullPayment.sol'), 'PullPayment.sol');
+    const killable = getInstrumentedVersion(util.getCode('zeppelin/Killable.sol'), 'Killable.sol');
     const inputs = {
       'Ownable.sol': ownable.contract,
       'PullPayment.sol': pullPayment.contract,
@@ -23,35 +23,45 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   });
 
   it('should compile after instrumenting zeppelin-solidity/Claimable.sol', () => {
-    const contract = util.getCode('zeppelin/Claimable.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const claimable = getInstrumentedVersion(util.getCode('zeppelin/Claimable.sol'), 'Claimable.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
+
     const inputs = {
-      'Ownable.sol': util.getCode('zeppelin/Ownable.sol'),
-      'Claimable.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'Claimable.sol': claimable.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
   it('should compile after instrumenting zeppelin-solidity/DayLimit.sol', () => {
-    const contract = util.getCode('zeppelin/DayLimit.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const dayLimit = getInstrumentedVersion(util.getCode('zeppelin/DayLimit.sol'), 'DayLimit.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
+    const shareable = getInstrumentedVersion(util.getCode('zeppelin/Shareable.sol'), 'Shareable.sol');
+
     const inputs = {
-      'Ownable.sol': util.getCode('zeppelin/Shareable.sol'),
-      'DayLimit.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'DayLimit.sol': dayLimit.contract,
+      'Shareable.sol': shareable.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
   it('should compile after instrumenting zeppelin-solidity/Killable.sol', () => {
-    const contract = util.getCode('zeppelin/Killable.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
+    const killable = getInstrumentedVersion(util.getCode('zeppelin/Killable.sol'), 'Killable.sol');
     const inputs = {
-      'Ownable.sol': util.getCode('zeppelin/Ownable.sol'),
-      'Killable.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'Killable.sol': killable.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
@@ -63,13 +73,15 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   });
 
   it('should compile after instrumenting zeppelin-solidity/Migrations.sol', () => {
-    const contract = util.getCode('zeppelin/Migrations.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
+    const migrations = getInstrumentedVersion(util.getCode('zeppelin/Migrations.sol'), 'Migrations.sol');
     const inputs = {
-      'Ownable.sol': util.getCode('zeppelin/Ownable.sol'),
-      'Migrations.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'Migrations.sol': migrations.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
@@ -81,15 +93,19 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   });
 
   it('should compile after instrumenting zeppelin-solidity/MultisigWallet.sol', () => {
-    const contract = util.getCode('zeppelin/MultisigWallet.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const multisig = getInstrumentedVersion(util.getCode('zeppelin/Multisig.sol'), 'Multisig.sol');
+    const shareable = getInstrumentedVersion(util.getCode('zeppelin/Shareable.sol'), 'Shareable.sol');
+    const dayLimit = getInstrumentedVersion(util.getCode('zeppelin/DayLimit.sol'), 'DayLimit.sol');
+    const multisigWallet = getInstrumentedVersion(util.getCode('zeppelin/MultisigWallet.sol'), 'MultisigWallet.sol');
     const inputs = {
-      'Multisig.sol': util.getCode('zeppelin/Multisig.sol'),
-      'Shareable.sol': util.getCode('zeppelin/Shareable.sol'),
-      'DayLimit.sol': util.getCode('zeppelin/DayLimit.sol'),
-      'MultisigWallet.sol': info.contract,
+      'Multisig.sol': multisig.contract,
+      'Shareable.sol': shareable.contract,
+      'DayLimit.sol': dayLimit.contract,
+      'MultisigWallet.sol': multisigWallet.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
@@ -122,36 +138,51 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   });
 
   it('should compile after instrumenting zeppelin-solidity/Stoppable.sol', () => {
-    const contract = util.getCode('zeppelin/Stoppable.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const stoppable = getInstrumentedVersion(util.getCode('zeppelin/Stoppable.sol'), 'Stoppable.sol');
+    const ownable = getInstrumentedVersion(util.getCode('zeppelin/Ownable.sol'), 'Ownable.sol');
     const inputs = {
-      'Ownable.sol': util.getCode('zeppelin/Ownable.sol'),
-      'Stoppable.sol': info.contract,
+      'Ownable.sol': ownable.contract,
+      'Stoppable.sol': stoppable.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
   // --- Tokens ---
   it('should compile after instrumenting zeppelin-solidity/BasicToken.sol', () => {
-    const contract = util.getCode('zeppelin/token/BasicToken.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const basicToken = getInstrumentedVersion(util.getCode('zeppelin/token/BasicToken.sol'), 'BasicToken.sol');
+    const safeMath = getInstrumentedVersion(util.getCode('zeppelin/SafeMath.sol'), 'SafeMath.sol');
+    const ERC20Basic = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20Basic.sol'), 'ERC20Basic.sol');
+
     const inputs = {
-      'ERC20Basic.sol': util.getCode('zeppelin/token/ERC20Basic.sol'),
-      'SafeMath.sol': util.getCode('zeppelin/SafeMath.sol'),
-      'BasicToken.sol': info.contract,
+      'ERC20Basic.sol': ERC20Basic.contract,
+      'SafeMath.sol': safeMath.contract,
+      'BasicToken.sol': basicToken.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
   it('should compile after instrumenting zeppelin-solidity/CrowdsaleToken.sol', () => {
-    const contract = util.getCode('zeppelin/token/CrowdsaleToken.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const crowdsaleToken = getInstrumentedVersion(util.getCode('zeppelin/token/CrowdsaleToken.sol'), 'CrowdsaleToken.sol');
+    const standardToken = getInstrumentedVersion(util.getCode('zeppelin/token/StandardToken.sol'), 'StandardToken.sol');
+    const ERC20Basic = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20Basic.sol'), 'ERC20Basic.sol');
+    const ERC20 = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20.sol'), 'ERC20.sol');
+    const safeMath = getInstrumentedVersion(util.getCode('zeppelin/SafeMath.sol'), 'SafeMath.sol');
+
     const inputs = {
-      'StandardToken.sol': util.getCode('zeppelin/token/StandardToken.sol'),
-      'CrowdsaleToken.sol': info.contract,
+      'StandardToken.sol': standardToken.contract,
+      'CrowdsaleToken.sol': crowdsaleToken.contract,
+      'ERC20Basic.sol': ERC20Basic.contract,
+      'ERC20.sol': ERC20.contract,
+      'SafeMath.sol': safeMath.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
@@ -170,25 +201,38 @@ describe('Battery test of production contracts: OpenZeppelin', () => {
   });
 
   it('should compile after instrumenting zeppelin-solidity/SimpleToken.sol', () => {
-    const contract = util.getCode('zeppelin/token/SimpleToken.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const standardToken = getInstrumentedVersion(util.getCode('zeppelin/token/StandardToken.sol'), 'StandardToken.sol');
+    const simpleToken = getInstrumentedVersion(util.getCode('zeppelin/token/SimpleToken.sol'), 'SimpleToken.sol');
+    const ERC20 = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20.sol'), 'ERC20.sol');
+    const safeMath = getInstrumentedVersion(util.getCode('zeppelin/SafeMath.sol'), 'SafeMath.sol');
+
     const inputs = {
-      'StandardToken.sol': util.getCode('zeppelin/token/StandardToken.sol'),
-      'SimpleToken.sol': info.contract,
+      'StandardToken.sol': standardToken.contract,
+      'SimpleToken.sol': simpleToken.contract,
+      'ERC20.sol': ERC20.contract,
+      'SafeMath.sol': safeMath.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 
   it('should compile after instrumenting zeppelin-solidity/StandardToken.sol', () => {
-    const contract = util.getCode('zeppelin/token/StandardToken.sol');
-    const info = getInstrumentedVersion(contract, 'test.sol');
+    const ERC20Basic = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20Basic.sol'), 'ERC20Basic.sol');
+    const standardToken = getInstrumentedVersion(util.getCode('zeppelin/token/StandardToken.sol'), 'StandardToken.sol');
+    const safeMath = getInstrumentedVersion(util.getCode('zeppelin/SafeMath.sol'), 'SafeMath.sol');
+    const ERC20 = getInstrumentedVersion(util.getCode('zeppelin/token/ERC20.sol'), 'ERC20.sol');
+
     const inputs = {
-      'ERC20Basic.sol': util.getCode('zeppelin/token/ERC20Basic.sol'),
-      'SafeMath.sol': util.getCode('zeppelin/SafeMath.sol'),
-      'StandardToken.sol': info.contract,
+      'ERC20Basic.sol': ERC20Basic.contract,
+      'SafeMath.sol': safeMath.contract,
+      'StandardToken.sol': standardToken.contract,
+      'ERC20.sol': ERC20.contract,
     };
-    const output = solc.compile(inputs, 1);
+    const output = solc.compile({
+      sources: inputs,
+    }, 1);
     util.report(output.errors);
   });
 });


### PR DESCRIPTION
I've done two things here, one more controversial than the other:

* Make sure the Zeppelin tests are actually doing something! For multi-contract compilations, we were passing the wrong object to solc, so an empty object was being returned, which obviously had no errors in it. Once that was corrected, some tests were also missing some files to be included

* Instrument all contracts in these tests, not just the one notionally being compiled. This would have caught the problems with upgrading to solc 0.4.8, whereas the previous tests, even if they had worked as intended, would not have done. We are (currently) always instrumenting all contracts, so it makes sense that that is what should be tested here.