### PR TITLE
Bump solidity-parser to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mkdirp": "^0.5.1",
     "shelljs": "^0.7.4",
     "sol-explore": "^1.6.2",
-    "solidity-parser": "0.2.0"
+    "solidity-parser": "0.3.0"
   },
   "devDependencies": {
     "crypto-js": "^3.1.9-1",

--- a/parse.js
+++ b/parse.js
@@ -45,6 +45,7 @@ const instrumenter = require('./instrumenter');
   'Program',
   'ReturnStatement',
   'SequenceExpression',
+  'StateVariableDeclaration',
   'StructDeclaration',
   'ThisExpression',
   'ThrowStatement',
@@ -188,9 +189,7 @@ parse.ContractOrLibraryStatement = function parseContractOrLibraryStatement(cont
   }
 
   expression.body.forEach(construct => {
-    if (!Array.isArray(construct)) {
-      parse[construct.type](contract, construct);
-    }
+    parse[construct.type](contract, construct);
   });
 };
 

--- a/test/sources/statements/tuple.sol
+++ b/test/sources/statements/tuple.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.3;
+
+contract Test {  
+    function a() {
+        var(x,y) = (10,20);
+    }
+}

--- a/test/statements.js
+++ b/test/statements.js
@@ -90,4 +90,24 @@ describe('generic statements', () => {
       done();
     }).catch(done);
   });
+
+  it('should cover a tuple statement', done => {
+    const contract = util.getCode('statements/tuple.sol');
+    const info = getInstrumentedVersion(contract, filePath);
+    const coverage = new CoverageMap();
+    coverage.addContract(info, filePath);
+
+    vm.execute(info.contract, 'a', []).then(events => {
+      const mapping = coverage.generate(events, pathPrefix);
+      assert.deepEqual(mapping[filePath].l, {
+        5: 1,
+      });
+      assert.deepEqual(mapping[filePath].b, {});
+      assert.deepEqual(mapping[filePath].s, {});
+      assert.deepEqual(mapping[filePath].f, {
+        1: 1,
+      });
+      done();
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
+ Upgrades solidity-parser (pins to 0.3.0)
+ Removes array check from body node parsing to match new AST format in solidity-parser
+ Adds stub for `StateVariableDeclaration` node in `parse.js`. (These are top level declarations that don't get coverage.)
+ Adds coverage test for a tuple declaration
+ Resolves #25 (possibly #16 as well).
